### PR TITLE
Support building on macosx-arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,17 @@ From macosx-amd64
   --target windows-amd64
   --target windows-arm64
   --target windows-i386
+From macosx-arm64
+  --target linux-amd64
+  --target linux-amd64-gnu.2.27
+  --target linux-amd64-gnu.2.28
+  --target linux-amd64-gnu.2.31
+  --target linux-i386
+  --target macosx-amd64
+  --target macosx-arm64
+  --target windows-amd64
+  --target windows-arm64
+  --target windows-i386
 From windows-amd64
   --target linux-amd64
   --target linux-amd64-gnu.2.27

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -109,15 +109,17 @@ const nimOStoZigOS = {
   "macosx": "macos",
 }.toTable()
 
-const zigurls = {
-  "macosx-amd64": "https://ziglang.org/download/0.9.0/zig-macos-x86_64-0.9.0.tar.xz",
-  "linux-amd64": "https://ziglang.org/download/0.9.0/zig-linux-x86_64-0.9.0.tar.xz",
-  "linux-i386": "https://ziglang.org/download/0.9.0/zig-linux-i386-0.9.0.tar.xz",
-  "windows-amd64": "https://ziglang.org/download/0.9.0/zig-windows-x86_64-0.9.0.zip",
-  "windows-i386": "https://ziglang.org/download/0.9.0/zig-windows-i386-0.9.0.zip",
-  "windows-arm64": "https://ziglang.org/download/0.9.0/zig-windows-aarch64-0.9.0.zip",
-}.toTable()
+const zigVersion = "0.9.0"
 
+const zigurls = {
+  "macosx-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-macos-x86_64-{zigVersion}.tar.xz",
+  "macosx-arm64": fmt"https://ziglang.org/download/{zigVersion}/zig-macos-aarch64-{zigVersion}.tar.xz",
+  "linux-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-x86_64-{zigVersion}.tar.xz",
+  "linux-i386": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-i386-{zigVersion}.tar.xz",
+  "windows-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-x86_64-{zigVersion}.zip",
+  "windows-i386": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-i386-{zigVersion}.zip",
+  "windows-arm64": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-aarch64-{zigVersion}.zip",
+}.toTable()
 
 proc mkArgs(zig_root: string, target: Target): seq[string] =
   ## Return the compiler args for the given target

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -12,6 +12,7 @@ var toskip = [
   "ssl_from_macosx-amd64_to_linux-amd64",
   "sqlite_from_windows-amd64_to_linux-amd64-gnu.2.27",
   "sqlite_from_macosx-amd64_to_linux-amd64-gnu.2.27",
+  "sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27",
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
 ]


### PR DESCRIPTION
Supporting cross compiling from an M1 mac.

I had to disable the `sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27` test, it fails with error

```
ld.lld: error: undefined symbol: fcntl64
>>> referenced by sqlite3.c
>>>               /Users/brendan/.cache/nim/main_d/sqlite3.c.o:(aSyscall)
Error: execution of an external program failed: '/Users/brendan/workspace/nim/brendo-m/nimxc/_tests/toolchains/zig-macos-aarch64-0.9.0/zigcc   -o /Users/brendan/workspace/nim/brendo-m/nimxc/_tests/tests/sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27/main  /Users/brendan/.cache/nim/main_d/sqlite3.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@sstd@sprivate@sdigitsutils.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@ssystem@sassertions.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@ssystem@sdollars.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@spure@scollections@ssharedlist.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@ssystem@sio.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@ssystem.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@spure@sdb_common.nim.c.o /Users/brendan/.cache/nim/main_d/@m..@s..@s..@s..@s..@s..@s..@s..@s..@sopt@shomebrew@sCellar@snim@s1.6.10@snim@slib@simpure@sdb_sqlite.nim.c.o /Users/brendan/.cache/nim/main_d/@mmain.nim.c.o  -pthread -lpthread  -target x86_64-linux-gnu.2.27 -fno-sanitize=undefined  -ldl'
# rc = 1
/Users/brendan/workspace/nim/brendo-m/nimxc/tests/test_everything.nim(69, 17): Check failed: rc == 0
rc was 1
[FAILED] sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27
```

This is an issue in ziglang itself and might be fixed in the next few releases. https://github.com/ziglang/zig/issues/9485