### PR TITLE
convert to a hybrid package

### DIFF
--- a/nimxc.nimble
+++ b/nimxc.nimble
@@ -5,6 +5,7 @@ author        = "Matt Haggard"
 description   = "A helper to get cross-compiling working"
 license       = "MIT"
 srcDir        = "src"
+installExt    = @["nim"]
 bin           = @["nimxc"]
 
 

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -212,7 +212,7 @@ proc install_toolchain*(host: Pair, target: Pair, dir = "") =
     return
   get_bundle(host, target).install(dir)
 
-const DEFAULT_TOOLCHAIN_DIR = expandTilde("~/.nimxc")
+const DEFAULT_TOOLCHAIN_DIR* = expandTilde("~/.nimxc")
 
 proc exec_nim_c*(host: Pair, target: Pair, toolchains: string, args: openArray[string]): int =
   ## Execute 'nim c' but cross-compile for the given `target`


### PR DESCRIPTION
I'd like to be able to call `exec_nim_c` programatically and the package needs to be a hybrid for this. I also need access to the `DEFAULT_TOOLCHAIN_DIR`.

Maybe this should have a version bump?
