### PR TITLE
Add linux-arm64 and bump zig to 0.10.1

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,9 +37,6 @@ jobs:
       with:
         name: binaries-${{ matrix.os }}
         path: binaries-${{ matrix.os }}.tgz
-    - name: Setup tmate session
-      if: ${{ failure() }}
-      uses: mxschmitt/action-tmate@v3
   run:
     needs: [compile]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,6 +37,9 @@ jobs:
       with:
         name: binaries-${{ matrix.os }}
         path: binaries-${{ matrix.os }}.tgz
+    - name: Setup tmate session
+      if: ${{ failure() }}
+      uses: mxschmitt/action-tmate@v3
   run:
     needs: [compile]
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ From linux-amd64
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -50,7 +49,6 @@ From linux-i386
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -63,7 +61,6 @@ From macosx-amd64
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -76,7 +73,6 @@ From macosx-arm64
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -89,7 +85,6 @@ From windows-amd64
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -102,7 +97,6 @@ From windows-arm64
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -115,7 +109,6 @@ From windows-i386
   --target linux-amd64-gnu.2.31
   --target linux-i386
   --target linux-arm64
-  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64

--- a/README.md
+++ b/README.md
@@ -36,6 +36,8 @@ From linux-amd64
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -47,6 +49,8 @@ From linux-i386
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -58,6 +62,8 @@ From macosx-amd64
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -69,6 +75,8 @@ From macosx-arm64
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -80,6 +88,8 @@ From windows-amd64
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -91,6 +101,8 @@ From windows-arm64
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64
@@ -102,6 +114,8 @@ From windows-i386
   --target linux-amd64-gnu.2.28
   --target linux-amd64-gnu.2.31
   --target linux-i386
+  --target linux-arm64
+  --target linux-riscv64
   --target macosx-amd64
   --target macosx-arm64
   --target windows-amd64

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -109,13 +109,15 @@ const nimOStoZigOS = {
   "macosx": "macos",
 }.toTable()
 
-const zigVersion = "0.9.0"
+const zigVersion = "0.10.1"
 
 const zigurls = {
   "macosx-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-macos-x86_64-{zigVersion}.tar.xz",
   "macosx-arm64": fmt"https://ziglang.org/download/{zigVersion}/zig-macos-aarch64-{zigVersion}.tar.xz",
   "linux-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-x86_64-{zigVersion}.tar.xz",
   "linux-i386": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-i386-{zigVersion}.tar.xz",
+  "linux-arm64": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-aarch64-{zigVersion}.tar.xz",
+  "linux-riscv64": fmt"https://ziglang.org/download/{zigVersion}/zig-linux-riscv64-{zigVersion}.tar.xz",
   "windows-amd64": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-x86_64-{zigVersion}.zip",
   "windows-i386": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-i386-{zigVersion}.zip",
   "windows-arm64": fmt"https://ziglang.org/download/{zigVersion}/zig-windows-aarch64-{zigVersion}.zip",
@@ -150,9 +152,11 @@ const targets : seq[Target] = @[
   ("linux", "amd64", "gnu.2.27"),
   ("linux", "amd64", "gnu.2.28"),
   ("linux", "amd64", "gnu.2.31"),
+  ("linux", "arm64", ""),
+  ("linux", "riscv64", ""),
   ("windows", "i386", ""),
   ("windows", "amd64", ""),
-  ("windows", "arm64", ""),   
+  ("windows", "arm64", ""),
 ]
 
 for host, url in zigurls.pairs:

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -148,7 +148,7 @@ const nimOStoZigOS = {
 const zigVersion = "0.10.1"
 
 const hostSDK = {
-  "windows": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.tar.gz",
+  "windows": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
 }.toTable()
 
 const sdkurl = "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.tar.xz"

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -122,6 +122,9 @@ proc install_sdk(src_url: string, toolchains: string) =
     if dlfilename.endsWith(".tar.gz"):
       let tmpdir = toolchains / "sdk"
       tar.extractAll(dlfilename, tmpdir)
+    if dlfilename.endsWith(".zip"):
+      let tmpdir = toolchains / "sdk"
+      zip.extractAll(dlfilename, tmpdir)
     else:
       var p = startProcess(findExe"tar",
         args=["-x", "-C", toolchains, "-f", dlfilename],

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -107,7 +107,8 @@ proc install_sdk(src_url: string, toolchains: string) =
   let dlcache = toolchains / "download"
   let dlfilename = dlcache / src_url.extractFilename()
   let dstsubdir = toolchains / dlfilename.extractFilename.changeFileExt("").changeFileExt("")
-
+  var dstdir = toolchains
+  dstdir.normalizePath()
   if not dstsubdir.dirExists:
     if not dlfilename.fileExists:
       # download it
@@ -119,7 +120,7 @@ proc install_sdk(src_url: string, toolchains: string) =
     # extract it
     echo &"Extracting {dlfilename} to {dstsubdir}"
     var p = startProcess(findExe"tar",
-      args=["--force-local", "-xf", dlfilename, "-C", toolchains],
+      args=["--force-local", "-x", "-C", dstdir, "-f", dlfilename],
       options={poStdErrToStdOut, poParentStreams})
     doAssert p.waitForExit() == 0
 

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -6,7 +6,8 @@ import std/strformat
 import std/strutils
 import std/tables
 
-import zippy/ziparchives
+import zippy/ziparchives as zip
+import zippy/tarballs as tar
 
 type
   Pair* = string
@@ -43,9 +44,7 @@ proc getDir*(url: string): string =
   let arname = url.extractFilename
   if arname.endsWith(".zip"):
     return arname.changeFileExt("")
-  elif arname.endsWith(".tar.xz"):
-    return arname.changeFileExt("").changeFileExt("")
-  return arname.changeFileExt("")
+  return arname.changeFileExt("").changeFileExt("")
 
 #======================================================================
 # Target definitions
@@ -73,7 +72,7 @@ proc install_zig(src_url: string, toolchains: string) =
     echo &"Extracting {dlfilename} to {dstsubdir}"
     if dlfilename.endsWith(".zip"):
       let tmpdir = toolchains / "tmp"
-      extractAll(dlfilename, tmpdir)
+      zip.extractAll(dlfilename, tmpdir)
       moveDir(tmpdir / dstsubdir.extractFilename, dstsubdir)
     else:
       var p = startProcess(findExe"tar",
@@ -120,9 +119,9 @@ proc install_sdk(src_url: string, toolchains: string) =
       client.downloadFile(src_url, dlfilename)
     # extract it
     echo &"Extracting {dlfilename} to {dstsubdir}"
-    if dlfilename.endsWith(".zip"):
+    if dlfilename.endsWith(".tar.gz"):
       let tmpdir = toolchains / "sdk"
-      extractAll(dlfilename, tmpdir)
+      tar.extractAll(dlfilename, tmpdir)
     else:
       var p = startProcess(findExe"tar",
         args=["-x", "-C", toolchains, "-f", dlfilename],
@@ -146,7 +145,7 @@ const nimOStoZigOS = {
 const zigVersion = "0.10.1"
 
 const hostSDK = {
-  "windows": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
+  "windows": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.tar.gz",
 }.toTable()
 
 const sdkurl = "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.tar.xz"

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -139,10 +139,6 @@ const nimOStoZigOS = {
 
 const zigVersion = "0.10.1"
 
-const winSdkUrl = {
-  "windows": "https://ivan.vandot.rs/macosx-sdk.14.2.tar.xz",
-}.toTable()
-
 const sdkurl = "https://ivan.vandot.rs/macosx-sdk.14.2.tar.xz"
 
 const zigurls = {

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -119,7 +119,7 @@ proc install_sdk(src_url: string, toolchains: string) =
     # extract it
     echo &"Extracting {dlfilename} to {dstsubdir}"
     var p = startProcess(findExe"tar",
-      args=["-x", "-C", toolchains, "-f", dlfilename],
+      args=["--force-local", "-x", "-C", toolchains, "-f", dlfilename],
       options={poStdErrToStdOut, poParentStreams})
     doAssert p.waitForExit() == 0
 
@@ -138,6 +138,10 @@ const nimOStoZigOS = {
 }.toTable()
 
 const zigVersion = "0.10.1"
+
+const winSdkUrl = {
+  "windows": "https://ivan.vandot.rs/macosx-sdk.14.2.tar.xz",
+}.toTable()
 
 const sdkurl = "https://ivan.vandot.rs/macosx-sdk.14.2.tar.xz"
 

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -147,7 +147,9 @@ const nimOStoZigOS = {
 const zigVersion = "0.10.1"
 
 const hostSDK = {
-  "windows": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
+  "windows-i386": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
+  "windows-amd64": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
+  "windows-arm64": "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.zip",
 }.toTable()
 
 const sdkurl = "https://github.com/vandot/nimxc/releases/download/sdk/macosx-sdk.14.2.tar.xz"
@@ -219,6 +221,7 @@ for host, url in zigurls.pairs:
         proc install(toolchains: string) {.closure.} =
           install_zig(this_url, toolchains)
           if "macosx" in $this_targ:
+            echo "THIS HOST: ", this_host
             let this_sdkurl = hostSDK.getOrDefault(this_host, sdkurl)
             install_sdk(this_sdkurl, toolchains)
         proc args(toolchains: string): seq[string] {.closure.} =

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -121,7 +121,7 @@ proc install_sdk(src_url: string, toolchains: string) =
     # extract it
     echo &"Extracting {dlfilename} to {dstsubdir}"
     if dlfilename.endsWith(".zip"):
-      let tmpdir = toolchains / "tmp"
+      let tmpdir = toolchains / "tmpsdk"
       extractAll(dlfilename, tmpdir)
       moveDir(tmpdir / dstsubdir.extractFilename, dstsubdir)
     else:

--- a/src/nimxc.nim
+++ b/src/nimxc.nim
@@ -119,7 +119,7 @@ proc install_sdk(src_url: string, toolchains: string) =
     # extract it
     echo &"Extracting {dlfilename} to {dstsubdir}"
     var p = startProcess(findExe"tar",
-      args=["--force-local", "-x", "-C", toolchains, "-f", dlfilename],
+      args=["--force-local", "-xf", dlfilename, "-C", toolchains],
       options={poStdErrToStdOut, poParentStreams})
     doAssert p.waitForExit() == 0
 

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -10,11 +10,16 @@ import nimxc
 var toskip = [
   "ssl_from_windows-amd64_to_linux-amd64",
   "ssl_from_macosx-amd64_to_linux-amd64",
+  "ssl_from_linux-arm64_to_macosx-arm64",
+  "ssl_from_linux-arm64_to_macosx-amd64",
   "sqlite_from_windows-amd64_to_linux-amd64-gnu.2.27",
   "sqlite_from_macosx-amd64_to_linux-amd64-gnu.2.27",
   "sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27",
+  "sqlite_from_linux-arm64_to_linux-amd64-gnu.2.27",
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
+  "threading_from_macosx-arm64_to_linux-amd64",
+  "threading_from_linux-arm64_to_linux-amd64",
 ]
 
 var samples: seq[string]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -43,6 +43,8 @@ var failed_tests: seq[string]
 
 if host_systems.hasKey(THIS_HOST):
   for target in host_systems[THIS_HOST].keys:
+    if "windows" in THIS_HOST and "macosx" in target:
+      continue
     for sample in samples:
       let testname = sample.extractFilename & "_from_" & THIS_HOST & "_to_" & target
       if testname in toskip:

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -21,6 +21,7 @@ var toskip = [
   "threading_from_macosx-amd64_to_linux-amd64",
   "threading_from_linux-arm64_to_linux-amd64",
   "threading_from_windows-amd64_to_linux-amd64",
+  "threading_from_windows-amd64_to_windows-arm64",
 ]
 
 var samples: seq[string]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -16,12 +16,6 @@ var toskip = [
   "sqlite_from_linux-arm64_to_linux-amd64-gnu.2.27", ## undefined symbol: fcntl64 https://github.com/ziglang/zig/pull/15101
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
-  # "threading_from_macosx-arm64_to_linux-amd64",
-  # "threading_from_macosx-amd64_to_windows-arm64",
-  # "threading_from_macosx-amd64_to_linux-amd64",
-  # "threading_from_linux-arm64_to_linux-amd64",
-  # "threading_from_windows-amd64_to_linux-amd64",
-  # "threading_from_windows-amd64_to_windows-arm64",
 ]
 
 var samples: seq[string]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -17,6 +17,7 @@ var toskip = [
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
   "threading_from_macosx-arm64_to_linux-amd64",
+  "threading_from_macosx-amd64_to_windows-arm64",
   "threading_from_linux-arm64_to_linux-amd64",
   "threading_from_windows-amd64_to_linux-amd64",
 ]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -68,9 +68,9 @@ if host_systems.hasKey(THIS_HOST):
         var args = @["c", "-o:" & dst]
         for arg in THIS_HOST.compile_args(target, toolchains_root):
           args.add(arg)
-        args.add(src.extractFilename)
         if testname == "threading_from_windows-amd64_to_linux-amd64":
-          args.add("-Wno-error=int-conversion")
+          args.add("--passC:-Wno-error=int-conversion  -fno-sanitize=undefined")
+        args.add(src.extractFilename)
         echo "cd " & subdir
         echo "nim " & args.mapIt("'" & it & "'").join(" ")
         var p = startProcess(command = findExe"nim", workingDir = subdir,

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -69,6 +69,8 @@ if host_systems.hasKey(THIS_HOST):
         for arg in THIS_HOST.compile_args(target, toolchains_root):
           args.add(arg)
         args.add(src.extractFilename)
+        if testname == "threading_from_windows-amd64_to_linux-amd64":
+          args.add("-Wno-error=int-conversion")
         echo "cd " & subdir
         echo "nim " & args.mapIt("'" & it & "'").join(" ")
         var p = startProcess(command = findExe"nim", workingDir = subdir,

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -18,6 +18,7 @@ var toskip = [
   "regex_from_macosx-amd64_to_linux-amd64",
   "threading_from_macosx-arm64_to_linux-amd64",
   "threading_from_linux-arm64_to_linux-amd64",
+  "threading_from_windows-amd64_to_linux-amd64",
 ]
 
 var samples: seq[string]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -10,12 +10,10 @@ import nimxc
 var toskip = [
   "ssl_from_windows-amd64_to_linux-amd64",
   "ssl_from_macosx-amd64_to_linux-amd64",
-  "ssl_from_linux-arm64_to_macosx-arm64",
-  "ssl_from_linux-arm64_to_macosx-amd64",
   "sqlite_from_windows-amd64_to_linux-amd64-gnu.2.27",
   "sqlite_from_macosx-amd64_to_linux-amd64-gnu.2.27",
-  "sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27",
-  "sqlite_from_linux-arm64_to_linux-amd64-gnu.2.27",
+  "sqlite_from_macosx-arm64_to_linux-amd64-gnu.2.27", ## undefined symbol: fcntl64 https://github.com/ziglang/zig/pull/15101
+  "sqlite_from_linux-arm64_to_linux-amd64-gnu.2.27", ## undefined symbol: fcntl64 https://github.com/ziglang/zig/pull/15101
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
   "threading_from_macosx-arm64_to_linux-amd64",

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -18,6 +18,7 @@ var toskip = [
   "regex_from_macosx-amd64_to_linux-amd64",
   "threading_from_macosx-arm64_to_linux-amd64",
   "threading_from_macosx-amd64_to_windows-arm64",
+  "threading_from_macosx-amd64_to_linux-amd64",
   "threading_from_linux-arm64_to_linux-amd64",
   "threading_from_windows-amd64_to_linux-amd64",
 ]

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -68,7 +68,7 @@ if host_systems.hasKey(THIS_HOST):
         var args = @["c", "-o:" & dst]
         for arg in THIS_HOST.compile_args(target, toolchains_root):
           args.add(arg)
-        if testname == "threading_from_windows-amd64_to_linux-amd64":
+        if testname in @["threading_from_windows-amd64_to_linux-amd64", "threading_from_macosx-amd64_to_linux-amd64"]:
           args.add("--passC:-Wno-error=int-conversion  -fno-sanitize=undefined")
         args.add(src.extractFilename)
         echo "cd " & subdir

--- a/tests/test_everything.nim
+++ b/tests/test_everything.nim
@@ -16,12 +16,12 @@ var toskip = [
   "sqlite_from_linux-arm64_to_linux-amd64-gnu.2.27", ## undefined symbol: fcntl64 https://github.com/ziglang/zig/pull/15101
   "regex_from_windows-amd64_to_linux-amd64",
   "regex_from_macosx-amd64_to_linux-amd64",
-  "threading_from_macosx-arm64_to_linux-amd64",
-  "threading_from_macosx-amd64_to_windows-arm64",
-  "threading_from_macosx-amd64_to_linux-amd64",
-  "threading_from_linux-arm64_to_linux-amd64",
-  "threading_from_windows-amd64_to_linux-amd64",
-  "threading_from_windows-amd64_to_windows-arm64",
+  # "threading_from_macosx-arm64_to_linux-amd64",
+  # "threading_from_macosx-amd64_to_windows-arm64",
+  # "threading_from_macosx-amd64_to_linux-amd64",
+  # "threading_from_linux-arm64_to_linux-amd64",
+  # "threading_from_windows-amd64_to_linux-amd64",
+  # "threading_from_windows-amd64_to_windows-arm64",
 ]
 
 var samples: seq[string]


### PR DESCRIPTION
Zig with version `0.9.1` changed behaviour when missing Mac OSX Frameworks from warning to error as explained [here](https://github.com/ziglang/zig/issues/10660#issuecomment-1028319874) 
This PR adds automatic SDK installation on Linux, while on Windows it expects for SDK to be preinstalled and path to it provided with `--sdk` flag. SDK has a lot of symlinks and any possible solution that I tried on Windows, packing it with `zip` or with `tar` using `--dereference`, didn't worked. Using any combination of `zip`, `7z`, `tar`, `zippy.ziparchives.extractAll() and `zippy.tarballs.extractAll()` failed.

Probably due what is explained in clang 15 [Release notes](https://releases.llvm.org/15.0.0/tools/clang/docs/ReleaseNotes.html)
```
The -Wint-conversion warning diagnostic for implicit int <-> pointer conversions now defaults to an error in all C language modes. It may be downgraded to a warning with -Wno-error=int-conversion, or disabled entirely with -Wno-int-conversion.
```
Now threading test from `windows|macosx` to `linux-amd64` fails with following error:
```
error: incompatible integer to pointer conversion passing 'unsigned long' to parameter of type 'pthread_t' (aka 'struct __pthread *') [-Wint-conversion]
        T1_ = pthread_join(t.sys, ((void**) NIM_NIL));
                           ^~~~~
```
Passing `-Wno-error=int-conversion` reverts its to a warning.

All Mac OSX SDKs can be found [here](https://xcodereleases.com/?scope=release) and download should be cleaned (keep only MacOSX stuff) and hosted somewhere, maybe as a repo's release artifact.

All tests passed in my fork - https://github.com/vandot/nimxc/actions/runs/4590217179